### PR TITLE
first commit

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,13 +6,13 @@ class ApplicationController < ActionController::Base
 
   def basic_auth
     authenticate_or_request_with_http_basic do |username, password|
-      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
+      username == ENV['BASIC_AUTH_USER'] && password == ENV['BASIC_AUTH_PASSWORD']
     end
   end
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:nick_name, :last_name, :first_name, :last_name_furigana, :first_name_furigana, :birth_day])
+    devise_parameter_sanitizer.permit(:sign_up,
+                                      keys: [:nick_name, :last_name, :first_name, :last_name_furigana, :first_name_furigana,
+                                             :birth_day])
   end
-
 end
-

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,17 +1,26 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create]
+  before_action :authenticate_user!, except: [:show, :index]
+  before_action :move_to_index, only: [:edit]
   def index
-    @items = Item.all.order("created_at DESC")
-    
+    @items = Item.all.order('created_at DESC')
   end
 
   def edit
+    @item = Item.find(params[:id])
+  end
 
+  def update
+    @item = Item.find(params[:id])
+    @item.update(item_params)
+    if @item.save
+      redirect_to item_path(@item.id)
+    else
+      render :edit
+    end
   end
 
   def new
     @item = Item.new
-
   end
 
   def create
@@ -21,22 +30,19 @@ class ItemsController < ApplicationController
     else
       render :new
     end
-
   end
 
   def show
     @item = Item.find(params[:id])
-
   end
 
-
-
-
-
-
+  def move_to_index
+    @item = Item.find(params[:id])
+    redirect_to action: :index unless current_user.id == @item.user.id
+  end
 
   def item_params
-    params.require(:item).permit(:title, :image, :value, :description, :delivery_id, :place_id, :how_long_id, :category_id, :status_id).merge(user_id: current_user.id)
+    params.require(:item).permit(:title, :image, :value, :description, :delivery_id, :place_id, :how_long_id, :category_id,
+                                 :status_id).merge(user_id: current_user.id)
   end
-
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -35,8 +35,9 @@ class ItemsController < ApplicationController
   end
 
   def move_to_index
-    @item = Item.find(params[:id])
-    redirect_to action: :index unless current_user.id == @item.user.id
+    unless current_user.id == @item.user.id
+      redirect_to action: :index 
+    end
   end
 
   def easy

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,18 +1,16 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:show, :index]
   before_action :move_to_index, only: [:edit]
+  before_action :easy, only: [:show, :edit, :update]
   def index
     @items = Item.all.order('created_at DESC')
   end
 
   def edit
-    @item = Item.find(params[:id])
   end
 
   def update
-    @item = Item.find(params[:id])
-    @item.update(item_params)
-    if @item.save
+    if @item.update(item_params)
       redirect_to item_path(@item.id)
     else
       render :edit
@@ -33,12 +31,15 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def move_to_index
     @item = Item.find(params[:id])
     redirect_to action: :index unless current_user.id == @item.user.id
+  end
+
+  def easy
+    @item = Item.find(params[:id])
   end
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,8 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:show, :index]
-  before_action :move_to_index, only: [:edit]
   before_action :easy, only: [:show, :edit, :update]
+  before_action :move_to_index, only: [:edit, :update]
+  
   def index
     @items = Item.all.order('created_at DESC')
   end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -13,8 +13,6 @@ class Category < ActiveHash::Base
     { id: 11, name: 'その他' }
   ]
 
-
   include ActiveHash::Associations
   has_many :items
-
 end

--- a/app/models/delivery.rb
+++ b/app/models/delivery.rb
@@ -5,8 +5,6 @@ class Delivery < ActiveHash::Base
     { id: 3, name: '送料込み（出品者負担）' }
   ]
 
-
   include ActiveHash::Associations
   has_many :items
-
 end

--- a/app/models/how_long.rb
+++ b/app/models/how_long.rb
@@ -6,8 +6,6 @@ class HowLong < ActiveHash::Base
     { id: 4, name: '4~7日で発送' }
   ]
 
-
   include ActiveHash::Associations
   has_many :items
-
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -11,16 +11,15 @@ class Item < ApplicationRecord
 
   with_options presence: true do
     validates :image
-    validates :title,  length: {maximum: 40}                             
-    validates :value,  numericality: {only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999}
-    validates :description,  length: {maximum: 1000}
+    validates :title,  length: { maximum: 40 }
+    validates :value,  numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 }
+    validates :description, length: { maximum: 1000 }
     validates :place_id, numericality: { other_than: 0 }
     with_options numericality: { other_than: 1 } do
       validates :delivery_id
-      validates :how_long_id 
+      validates :how_long_id
       validates :category_id
       validates :status_id
     end
   end
-   
 end

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -1,20 +1,20 @@
 class Place < ActiveHash::Base
   self.data = [
-    {id: 0, name: '--'}, {id: 1, name: '北海道'}, {id: 2, name: '青森県'}, 
-    {id: 3, name: '岩手県'}, {id: 4, name: '宮城県'}, {id: 5, name: '秋田県'}, 
-    {id: 6, name: '山形県'}, {id: 7, name: '福島県'}, {id: 8, name: '茨城県'}, 
-    {id: 9, name: '栃木県'}, {id: 10, name: '群馬県'}, {id: 11, name: '埼玉県'}, 
-    {id: 12, name: '千葉県'}, {id: 13, name: '東京都'}, {id: 14, name: '神奈川県'}, 
-    {id: 15, name: '新潟県'}, {id: 16, name: '富山県'}, {id: 17, name: '石川県'}, 
-    {id: 18, name: '福井県'}, {id: 19, name: '山梨県'}, {id: 20, name: '長野県'}, 
-    {id: 21, name: '岐阜県'}, {id: 22, name: '静岡県'}, {id: 23, name: '愛知県'}, 
-    {id: 24, name: '三重県'}, {id: 25, name: '滋賀県'}, {id: 26, name: '京都府'}, 
-    {id: 27, name: '大阪府'}, {id: 28, name: '兵庫県'}, {id: 29, name: '奈良県'}, 
-    {id: 30, name: '和歌山県'}, {id: 31, name: '鳥取県'}, {id: 32, name: '島根県'}, 
-    {id: 33, name: '岡山県'}, {id: 34, name: '広島県'}, {id: 35, name: '山口県'}, 
-    {id: 36, name: '徳島県'}, {id: 37, name: '香川県'}, {id: 38, name: '愛媛県'}, 
-    {id: 39, name: '高知県'}, {id: 40, name: '福岡県'}, {id: 41, name: '佐賀県'}, 
-    {id: 42, name: '長崎県'}, {id: 43, name: '熊本県'}, {id: 44, name: '大分県'}, 
-    {id: 45, name: '宮崎県'}, {id: 46, name: '鹿児島県'}, {id: 47, name: '沖縄県'}
-              ]
+    { id: 0, name: '--' }, { id: 1, name: '北海道' }, { id: 2, name: '青森県' },
+    { id: 3, name: '岩手県' }, { id: 4, name: '宮城県' }, { id: 5, name: '秋田県' },
+    { id: 6, name: '山形県' }, { id: 7, name: '福島県' }, { id: 8, name: '茨城県' },
+    { id: 9, name: '栃木県' }, { id: 10, name: '群馬県' }, { id: 11, name: '埼玉県' },
+    { id: 12, name: '千葉県' }, { id: 13, name: '東京都' }, { id: 14, name: '神奈川県' },
+    { id: 15, name: '新潟県' }, { id: 16, name: '富山県' }, { id: 17, name: '石川県' },
+    { id: 18, name: '福井県' }, { id: 19, name: '山梨県' }, { id: 20, name: '長野県' },
+    { id: 21, name: '岐阜県' }, { id: 22, name: '静岡県' }, { id: 23, name: '愛知県' },
+    { id: 24, name: '三重県' }, { id: 25, name: '滋賀県' }, { id: 26, name: '京都府' },
+    { id: 27, name: '大阪府' }, { id: 28, name: '兵庫県' }, { id: 29, name: '奈良県' },
+    { id: 30, name: '和歌山県' }, { id: 31, name: '鳥取県' }, { id: 32, name: '島根県' },
+    { id: 33, name: '岡山県' }, { id: 34, name: '広島県' }, { id: 35, name: '山口県' },
+    { id: 36, name: '徳島県' }, { id: 37, name: '香川県' }, { id: 38, name: '愛媛県' },
+    { id: 39, name: '高知県' }, { id: 40, name: '福岡県' }, { id: 41, name: '佐賀県' },
+    { id: 42, name: '長崎県' }, { id: 43, name: '熊本県' }, { id: 44, name: '大分県' },
+    { id: 45, name: '宮崎県' }, { id: 46, name: '鹿児島県' }, { id: 47, name: '沖縄県' }
+  ]
 end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -9,8 +9,6 @@ class Status < ActiveHash::Base
     { id: 7, name: '全体的に状態が悪い' }
   ]
 
-
   include ActiveHash::Associations
   has_many :items
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,31 +1,22 @@
 class User < ApplicationRecord
   has_many :items
 
-
   devise :database_authenticatable, :registerable, :recoverable, :rememberable, :validatable
   with_options presence: true do
-    validates :nick_name                             
+    validates :nick_name
     validates :birth_day
 
-    with_options format: { with: /\A[ぁ-んァ-ン一-龥々]+\z/} do
+    with_options format: { with: /\A[ぁ-んァ-ン一-龥々]+\z/ } do
       validates :first_name
       validates :last_name
-    end   
+    end
 
-    with_options format: { with: /\A[ァ-ヶー]+\z/} do
+    with_options format: { with: /\A[ァ-ヶー]+\z/ } do
       validates :first_name_furigana
       validates :last_name_furigana
-    end   
-
+    end
   end
-  
-  
 
-  
-
-
-  PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?[\d])[a-z\d]+\z/i.freeze
+  PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i.freeze
   validates_format_of :password, with: PASSWORD_REGEX
-
-
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,10 +7,10 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with(model: @item, local: true) do |f| %>
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
+    <%= render 'shared/error_messages', model: f.object %>
     <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
     <%# 出品画像 %>
@@ -23,7 +23,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /出品画像 %>
@@ -33,13 +33,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :title, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :description, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +52,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:status_id, Status.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +73,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:delivery_id, Delivery.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:place_id, Place.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:how_long_id, HowLong.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +101,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :value, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -140,8 +140,8 @@ app/assets/stylesheets/items/new.css %>
     <%# /注意書き %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
-      <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%= f.submit "変更する",class:"sell-btn" %>
+      <%=link_to 'もどる', item_path(@item.id), class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -9,9 +9,8 @@ app/assets/stylesheets/items/new.css %>
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with(model: @item, local: true) do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
     <%= render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+ 
 
     <%# 出品画像 %>
     <div class="img-upload">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
 
     <% if user_signed_in? %>
       <% if current_user.id == @item.user.id %>
-        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+        <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
       <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:edit, :index, :new, :show, :create]
+  resources :items, only: [:edit, :index, :new, :show, :create, :update]
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,17 +1,16 @@
 FactoryBot.define do
   factory :item do
-    title                           {'机'}
-    value                           {13000}
-    description                     {'状態いいよーーー＾ー＾！'}
-    delivery_id                     {3}
-    place_id                        {4}
-    how_long_id                     {2}
-    category_id                     {3}
-    status_id                       {3}
+    title                           { '机' }
+    value                           { 13_000 }
+    description                     { '状態いいよーーー＾ー＾！' }
+    delivery_id                     { 3 }
+    place_id                        { 4 }
+    how_long_id                     { 2 }
+    category_id                     { 3 }
+    status_id                       { 3 }
     association :user
     after(:build) do |item|
       item.image.attach(io: File.open('public/images/test_image.png'), filename: 'test_image.png')
     end
   end
-
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,16 +1,13 @@
 FactoryBot.define do
   factory :user do
-    nick_name                    {'玉五郎'}
-    email                        {Faker::Internet.free_email}
-    password                     { '1a' + Faker::Internet.password(min_length: 6) }
-    password_confirmation        {password}
-    last_name                    {'神田'}
-    first_name                   {'義彦'}
-    last_name_furigana           {'カンダ'}
-    first_name_furigana          {'ヨシヒコ'}
-    birth_day                    {Faker::Date.between_except(from: 20.year.ago, to: 1.year.from_now, excepted: Date.today) }
-
-
-
+    nick_name                    { '玉五郎' }
+    email                        { Faker::Internet.free_email }
+    password                     { "1a#{Faker::Internet.password(min_length: 6)}" }
+    password_confirmation        { password }
+    last_name                    { '神田' }
+    first_name                   { '義彦' }
+    last_name_furigana           { 'カンダ' }
+    first_name_furigana          { 'ヨシヒコ' }
+    birth_day                    { Faker::Date.between_except(from: 20.year.ago, to: 1.year.from_now, excepted: Date.today) }
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -6,18 +6,13 @@ RSpec.describe Item, type: :model do
   end
 
   describe '商品出品登録' do
-
     context '正常系' do
       it '全ての情報が指定された内容通り存在すれば登録できる' do
         expect(@item).to be_valid
       end
-
-
     end
 
-
     context '異常系' do
-
       it '商品名が空では出品できない' do
         @item.title = ''
         @item.valid?
@@ -34,7 +29,6 @@ RSpec.describe Item, type: :model do
         @item.description = ''
         @item.valid?
         expect(@item.errors.full_messages).to include("Description can't be blank")
-
       end
 
       it '価格を入力していないと出品できない' do
@@ -46,69 +40,63 @@ RSpec.describe Item, type: :model do
       it '価格は300円以下では出品できない' do
         @item.value = 299
         @item.valid?
-        expect(@item.errors.full_messages).to include("Value must be greater than or equal to 300")
+        expect(@item.errors.full_messages).to include('Value must be greater than or equal to 300')
       end
 
       it '価格は10000000円以上では出品できない' do
-        @item.value = 10000000
+        @item.value = 10_000_000
         @item.valid?
-        expect(@item.errors.full_messages).to include("Value must be less than or equal to 9999999")
+        expect(@item.errors.full_messages).to include('Value must be less than or equal to 9999999')
       end
 
       it '価格は全角文字では出品できない' do
         @item.value = '１４５６'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Value is not a number")
+        expect(@item.errors.full_messages).to include('Value is not a number')
       end
 
       it '価格は半角英数混合では出品できない' do
         @item.value = '1345ad'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Value is not a number")
+        expect(@item.errors.full_messages).to include('Value is not a number')
       end
 
       it '価格は半角英語だけでは出品できない' do
         @item.value = 'abcdefg'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Value is not a number")
+        expect(@item.errors.full_messages).to include('Value is not a number')
       end
-
-
-
 
       it '配送料の負担を選択していないと出品できない' do
         @item.delivery_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Delivery must be other than 1")
+        expect(@item.errors.full_messages).to include('Delivery must be other than 1')
       end
 
       it '発送元の地域を選択していないと出品できない' do
         @item.place_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include("Place must be other than 0")
+        expect(@item.errors.full_messages).to include('Place must be other than 0')
       end
 
       it '発送までの日数を選択していないと出品できない' do
         @item.how_long_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("How long must be other than 1")
+        expect(@item.errors.full_messages).to include('How long must be other than 1')
       end
 
       it 'カテゴリーを選択していないと出品できない' do
         @item.category_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category must be other than 1")
+        expect(@item.errors.full_messages).to include('Category must be other than 1')
       end
 
       it '商品の状態を選択していないと出品できない' do
         @item.status_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Status must be other than 1")
-
+        expect(@item.errors.full_messages).to include('Status must be other than 1')
       end
-
     end
-
   end
-  #pending "add some examples to (or delete) #{__FILE__}"
+  # pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,14 +1,11 @@
 require 'rails_helper'
 
-
-
 RSpec.describe User, type: :model do
   before do
     @user = FactoryBot.build(:user)
   end
 
   describe 'ユーザー新規登録' do
-
     context '正常系' do
       it '全ての情報が指定された内容通り存在すれば登録できる' do
         expect(@user).to be_valid
@@ -19,7 +16,6 @@ RSpec.describe User, type: :model do
         expect(@user).to be_valid
       end
     end
-
 
     context '異常系' do
       it 'nick_nameが空では登録できない' do
@@ -36,8 +32,7 @@ RSpec.describe User, type: :model do
       it 'emailが@を含んでいないと登録できない' do
         @user.email = 'kkjou88'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Email is invalid")
-
+        expect(@user.errors.full_messages).to include('Email is invalid')
       end
 
       it '重複したemailが存在する場合登録できない' do
@@ -45,7 +40,7 @@ RSpec.describe User, type: :model do
         another_user = FactoryBot.build(:user)
         another_user.email = @user.email
         another_user.valid?
-        expect(another_user.errors.full_messages).to include("Email has already been taken")
+        expect(another_user.errors.full_messages).to include('Email has already been taken')
       end
 
       it 'passwordが空では登録できない' do
@@ -63,27 +58,26 @@ RSpec.describe User, type: :model do
       it 'passwordが6文字以上でないと登録できない' do
         @user.password = '111aa'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password is too short (minimum is 6 characters)") 
+        expect(@user.errors.full_messages).to include('Password is too short (minimum is 6 characters)')
       end
 
       it 'passwordが英語のみでは登録できない' do
         @user.password = 'aaaaaa'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password") 
+        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
       end
 
       it 'passwordが数字のみでは登録できない' do
         @user.password = '111111'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password is invalid") 
+        expect(@user.errors.full_messages).to include('Password is invalid')
       end
 
       it 'passwordが全角では登録できない' do
         @user.password = '１１１DFG'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password is invalid") 
+        expect(@user.errors.full_messages).to include('Password is invalid')
       end
-
 
       it 'last_nameが空では登録できない' do
         @user.last_name = ''
@@ -100,25 +94,25 @@ RSpec.describe User, type: :model do
       it 'first_nameが漢字・平仮名・カタカナ以外では登録できない' do
         @user.first_name = 'Yusuke'
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name is invalid") 
+        expect(@user.errors.full_messages).to include('First name is invalid')
       end
 
       it 'first_name_furiganaが全角カタカナ以外では登録できない' do
         @user.first_name_furigana = '一樹'
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name furigana is invalid") 
+        expect(@user.errors.full_messages).to include('First name furigana is invalid')
       end
 
       it 'last_nameが漢字・平仮名・カタカナ以外では登録できない' do
         @user.first_name = 'Matuda'
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name is invalid") 
+        expect(@user.errors.full_messages).to include('First name is invalid')
       end
 
       it 'last_name_furiganaが全角カタカナ以外では登録できない' do
         @user.last_name_furigana = '松田'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Last name furigana is invalid") 
+        expect(@user.errors.full_messages).to include('Last name furigana is invalid')
       end
 
       it 'last_name_furiganaが空では登録できない' do
@@ -139,11 +133,7 @@ RSpec.describe User, type: :model do
         expect(@user.errors.full_messages).to include("Birth day can't be blank")
       end
     end
-
   end
 
-  #pending "add some examples to (or delete) #{__FILE__}"
+  # pending "add some examples to (or delete) #{__FILE__}"
 end
-
-
-

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,53 +44,51 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching :focus
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
-  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
-  #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
-  config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+  #   # This allows you to limit a spec run to individual examples or groups
+  #   # you care about by tagging them with `:focus` metadata. When nothing
+  #   # is tagged with `:focus`, all examples get run. RSpec also provides
+  #   # aliases for `it`, `describe`, and `context` that include `:focus`
+  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  #   config.filter_run_when_matching :focus
+  #
+  #   # Allows RSpec to persist some state between runs in order to support
+  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
+  #   # you configure your source control system to ignore this file.
+  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  #
+  #   # Limits the available syntax to the non-monkey patched syntax that is
+  #   # recommended. For more details, see:
+  #   #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
+  #   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
+  #   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
+  #   config.disable_monkey_patching!
+  #
+  #   # Many RSpec users commonly either run the entire suite or an individual
+  #   # file, and it's useful to allow more verbose output when running an
+  #   # individual spec file.
+  #   if config.files_to_run.one?
+  #     # Use the documentation formatter for detailed output,
+  #     # unless a formatter has already been configured
+  #     # (e.g. via a command-line flag).
+  #     config.default_formatter = "doc"
+  #   end
+  #
+  #   # Print the 10 slowest examples and example groups at the
+  #   # end of the spec run, to help surface which specs are running
+  #   # particularly slow.
+  #   config.profile_examples = 10
+  #
+  #   # Run specs in random order to surface order dependencies. If you find an
+  #   # order dependency and want to debug it, you can fix the order by providing
+  #   # the seed, which is printed after each run.
+  #   #     --seed 1234
+  #   config.order = :random
+  #
+  #   # Seed global randomization in this process using the `--seed` CLI option.
+  #   # Setting this allows you to use `--seed` to deterministically reproduce
+  #   # test failures related to randomization by passing the same `--seed` value
+  #   # as the one that triggered the failure.
+  #   Kernel.srand config.seed
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :selenium, using: :chrome, screen_size: [1400, 1400]

--- a/test/channels/application_cable/connection_test.rb
+++ b/test/channels/application_cable/connection_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class ApplicationCable::ConnectionTest < ActionCable::Connection::TestCase
   # test "connects with cookies" do


### PR DESCRIPTION
# What
商品情報編集機能の実装

# Why
カリキュラムの指示があったため
Gyazo　URL

ログイン状態の出品者は、商品情報編集ページに遷移できる動画
商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画
https://gyazo.com/9f2072a8ea1ccd5def35cc588f27adc9

正しく情報を記入すると、商品の情報を編集できる動画
https://gyazo.com/84e0ede59fd34a802bde57d18742da52

入力に問題のある状態では商品の情報は編集できず、エラーメッセージが出力される動画
https://gyazo.com/a0c1fcb085d2b7664c05cd55108b94e9

何も編集せずに更新をしても画像無しの商品にならない動画
https://gyazo.com/98a7987a1fe4e721ee4675b5760fde68

ログイン状態のユーザーであっても、URLを直接入力して出品していない商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画
https://gyazo.com/dc06374985337a0c30fe167198b4898a

ログアウト状態のユーザーは、URLを直接入力して商品情報編集ページへ遷移しようとすると、ログインページに遷移する動画
https://gyazo.com/3ace116f79fefc033226d725ec200d1b


注）　購入機能に関しては実装していないため、一部残している箇所もある